### PR TITLE
commit adds travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: node_js


### PR DESCRIPTION
The travis.yml file is necessary, as it tells travis CI
that this is a node project and what to build according
to what is specified in this file.