### PR TITLE
Add a config file, and a module to handle its access

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,8 @@ var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
 var nunjucks = require('nunjucks');
 
+var config = require('./local_modules/config');
+
 var index = require('./routes/index');
 var users = require('./routes/users');
 

--- a/bin/www
+++ b/bin/www
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+var config = require('../local_modules/config');
+
 /**
  * Module dependencies.
  */
@@ -9,10 +11,13 @@ var debug = require('debug')('lucca:server');
 var http = require('http');
 
 /**
- * Get port from environment and store in Express.
+ * Get interface address and port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
+var bind_addr = process.env.BIND_ADDRESS || config.get('Server', 'bind_address') || '0.0.0.0';
+app.set('bind_addr', bind_addr);
+
+var port = normalizePort(process.env.PORT || config.get('Server', 'bind_port') || '3000');
 app.set('port', port);
 
 /**
@@ -22,10 +27,10 @@ app.set('port', port);
 var server = http.createServer(app);
 
 /**
- * Listen on provided port, on all network interfaces.
+ * Listen on provided port, on specified network interface(s).
  */
 
-server.listen(port);
+server.listen(port, bind_addr);
 server.on('error', onError);
 server.on('listening', onListening);
 

--- a/local_modules/config.js
+++ b/local_modules/config.js
@@ -1,0 +1,34 @@
+// fetch server runtime parameters from conf file
+var ConfigParser = require('configparser');
+
+var conf_name = 'lucca.conf';
+
+const config = new ConfigParser();
+config.read(conf_name);
+
+config._write = config.write;
+config.write = function(){
+  this._write(conf_name);
+}
+
+module.exports = config;
+
+// The most relevant API features exposed by this wrapper module are:
+//
+// config.sections()
+//   - returns a list of strings containing the names of all sections defined
+//     in the config file.
+//
+// config.get('Section_Name', 'parameter_ame')
+//   - returns a string containing the value of the requested parameter in the
+//     given section, if it exists (or undefined it it does not))
+//
+// config.set('Section_Name', 'parameter_name', 'value')
+//   - alters the in-memory cached copy of the config to set the specified
+//     parameter to the given value. This change is application-wide.
+//
+// config.write()
+//   - flushes the in-memory copy of the config, overwriting the config file
+//     with any changes that have been made with .set() and .addSection()
+//
+// see https://github.com/ZachPerkitny/configparser for "full documentation"

--- a/lucca.conf
+++ b/lucca.conf
@@ -1,0 +1,25 @@
+[General]
+; the 'General' section is for general behavioral parameters that can be used
+;   to tune the system usage and maintenance experience for users and admins
+
+; 'badge_override_interval' is the length of time, in seconds, that an admin
+;   has to swipe their badge at a station after a user swipes and is rejected
+;   in order to indicate "trained" status for the user
+badge_override_interval=10
+
+[Server]
+; the 'Server' section is for config parameters that control how the express
+;   server core behaves (e.g. address and port to bind to)
+
+bind_address=0.0.0.0
+
+bind_port=3000
+
+[Database]
+; the 'Database' section is for parameters used by the database module. this
+;   includes parameters such as the IP address of the database server to
+;   connect to
+
+remote_hostname=localhost
+
+remote_port=5432

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "morgan": "~1.8.1",
     "nunjucks": "^3.0.1",
     "request": "^2.83.0",
-    "serve-favicon": "~2.4.2"
+    "serve-favicon": "~2.4.2",
+    "configparser": "~0.1.5"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
This branch creates a simple `.ini`-style config file (which is expected to grow with further development reveals additional uses for it), and a short module that handles loading and overwriting it.