### PR TITLE
api: add route api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ python:
 before_script: 
   - chmod 0777 ./node_modules/.bin/mocha
   - npm start &
-  - python ./test/bin/station-sim.py3
+#Command to run python test
+script: python ./test/bin/station-sim.py3 -c localhost:3000 -U --no-certificate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: node_js
 node_js:
   - "node"
+python:
+  - "3.6"
 
 #This script should fix the "Error - Mocha permissions denied"
 before_script: 
   - chmod 0777 ./node_modules/.bin/mocha
   - npm start &
+  - python ./test/bin/station-sim.py3

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ var nunjucks = require('nunjucks');
 
 var index = require('./routes/index');
 var users = require('./routes/users');
+var api = require('./routes/api');
 
 var app = express();
 
@@ -29,6 +30,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', index);
 app.use('/users', users);
+app.use('/api', api);
 
 
 // catch 404 and forward to error handler

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "test": "mocha",
-    "test-api": "python3 ./test/bin/station-sim.py3 -c localhost:3000 -U --no-certificate"
+    "test": "mocha"
   },
   "dependencies": {
     "body-parser": "~1.17.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "test": "mocha"
+    "test": "mocha",
+    "test-api": "python3 ./test/bin/station-sim.py3 -c localhost:3000 -U --no-certificate"
   },
   "dependencies": {
     "body-parser": "~1.17.1",

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,0 +1,28 @@
+var express = require('express');
+var router = express.Router();
+
+// log request
+router.use(function(req, res, next) {
+    console.log('%s %s', req.method, req.url);
+    next(); 
+});
+
+router.post('/user-access', function(req, res) {
+    var stationState = 'Enabled';
+    if(!req.body || req.body.length === 0 || req.body.length > 200) {
+        res.set({
+            'Content-Typer': 'text/plain',
+            'Station-State': stationState = 'Disabled'
+        });
+        res.status(403).send('FORBIDDEN');
+    } else {
+        res.set({
+            'Content-Type': 'text/plain',
+            'User-Id-String': req.body.id,
+            'Station-State': stationState
+        });
+        res.status(200).send('OK');
+    }        
+});
+
+module.exports = router;


### PR DESCRIPTION
User access api confirms proper header and
other confirmations detailed in the spec
documentation.

Test=Run ./station-sim.py3 -c localhost:3000 -U --no-ssl
        in another terminal while running app with node start