### PR TITLE
Added route protection and conditional nav bar admin items

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -10,11 +10,11 @@ module.exports = function (passport) {
 
   /* GET home page. */
   router.get('/', function (req, res) {
-    res.render('HomePage.njk');
+    res.render('HomePage.njk', { authenticated: req.isAuthenticated() });
   });
 
   router.get('/adminLogin', function (req, res) {
-    res.render('adminLogin.njk');
+    res.render('adminLogin.njk', { authenticated: req.isAuthenticated() });
   });
 
   router.post('/adminLogin', passport.authenticate('login', {
@@ -22,26 +22,26 @@ module.exports = function (passport) {
     failureRedirect: '/adminLogin'
   }));
 
-  router.get('/adminRegister', function (req, res) {
-    res.render('adminRegister.njk');
+  router.get('/adminRegister', checkAuth, function (req, res) {
+    res.render('adminRegister.njk', { authenticated: true });
   });
 
-  router.post('/adminRegister', passport.authenticate('register', {
+  router.post('/adminRegister', checkAuth, passport.authenticate('register', {
     successRedirect: '/adminLogin',
     failureRedirect: '/adminRegister'
   }));
 
-  router.get('/adminReset', function (req, res) {
-    res.render('adminReset.njk');
+  router.get('/adminReset', checkAuth, function (req, res) {
+    res.render('adminReset.njk', { authenticated: true });
   });
 
-  router.post('/adminReset', passport.authenticate('reset', {
+  router.post('/adminReset', checkAuth, passport.authenticate('reset', {
     successRedirect: '/adminLogin',
     failureRedirect: '/adminReset'
   }));
 
   router.get('/badgein', function (req, res) {
-    res.render('badgein.njk');
+    res.render('badgein.njk', { authenticated: req.isAuthenticated() });
   });
 
   /* GET registration page. Should be directed here from /badgein if/when the
@@ -49,7 +49,7 @@ module.exports = function (passport) {
    *     for user to fill out. 
    * *******************************************************************************************/
   router.get('/registration/:badge', function (req, res) {
-    res.render('registration.njk');
+    res.render('registration.njk', { authenticated: req.isAuthenticated() });
   });
 
   /* POST registration page. Uses form data to create a new user in the database.
@@ -100,7 +100,7 @@ module.exports = function (passport) {
   });
 
   router.get('/badgeinSuccess', function (req, res) {
-    res.render('badgeinSuccess.njk');
+    res.render('badgeinSuccess.njk', { authenticated: req.isAuthenticated() });
   });
 
   router.post('/badgeinSuccess', jsonParser, function (req, res) {
@@ -115,24 +115,24 @@ module.exports = function (passport) {
     res.redirect('/');
   });
 
-  router.get('/userManagement', function (req, res) {
+  router.get('/userManagement', checkAuth, function (req, res) {
     dbAPI.getUsers('2000-01-01', '3000-01-01').then(function (ret) {
-      res.render('userManagement.njk', { obj: ret });
+      res.render('userManagement.njk', { obj: ret, authenticated: true });
     });
   });
 
-  router.post('/userManagement', function (req, res) {
+  router.post('/userManagement', checkAuth, function (req, res) {
     dbAPI.validateUser(req.body.userInput).then(function (ret) {
       console.log(ret.dataValues);
       res.render('userManagement.njk', { obj: [ret.dataValues] });
     });
   });
 
-  router.get('/stationManagement/:filter', jsonParser, getStnMngmnt);
+  router.get('/stationManagement/:filter', checkAuth, jsonParser, getStnMngmnt);
 
-  router.post('/stationManagement/:filter', jsonParser, postStnMngr, getStnMngmnt);
+  router.post('/stationManagement/:filter', checkAuth, jsonParser, postStnMngr, getStnMngmnt);
 
-  router.post('/userManagement/deleteUser/:badge', function (req, res) {
+  router.post('/userManagement/deleteUser/:badge', checkAuth, function (req, res) {
     if (!req.body) {
       return res.sendStatus(400);
     }
@@ -144,7 +144,7 @@ module.exports = function (passport) {
     res.redirect('/userManagement');
   });
 
-  router.post('/userManagement/confirmUser/:badge', function (req, res) {
+  router.post('/userManagement/confirmUser/:badge', checkAuth, function (req, res) {
     if (!req.body) {
       return res.sendStatus(400);
     }
@@ -160,7 +160,7 @@ module.exports = function (passport) {
     res.redirect('/userManagement');
   });
 
-  router.post('/userManagement/deletePrivilege/:badge/:station', function (req, res) {
+  router.post('/userManagement/deletePrivilege/:badge/:station', checkAuth, function (req, res) {
     if (!req.body) {
       return res.sendStatus(400);
     }
@@ -172,7 +172,7 @@ module.exports = function (passport) {
     res.redirect('/userManagement');
   });
 
-  router.post('/userManagement/grantPrivilege/:badge/:station', function (req, res) {
+  router.post('/userManagement/grantPrivilege/:badge/:station', checkAuth, function (req, res) {
     if (!req.body) {
       return res.sendStatus(400);
     }
@@ -208,7 +208,8 @@ function getStnMngmnt(req, res) {
 
   var data = {
     messageType: req.messageType,
-    message: req.message
+    message: req.message,
+    authenticated: true
   }
 
   //get results from database that match filter

--- a/views/HomePage.njk
+++ b/views/HomePage.njk
@@ -1,35 +1,31 @@
 {% extends '_layout.njk' %}
 
-    {% block description %}
-    <meta name="description" content="LUCCA HomePage.">
-    {% endblock %}
+{% block description %}
+<meta name="description" content="LUCCA HomePage.">
+{% endblock %}
 
-    {% block title %}
-    <title>LUCCA HomePage</title>
-    {% endblock %}
+{% block title %}
+<title>LUCCA HomePage</title>
+{% endblock %}
 
-    <!-- Custom styles for this template -->
-    {% block customCSS %}
-    <link rel="stylesheet" href="stylesheets/navbar.css">
-    {% endblock %}
+<!-- Custom styles for this template -->
+{% block customCSS %}
+<link rel="stylesheet" href="stylesheets/navbar.css">
+{% endblock %}
 
-    {% block Home %}
-    <li class="nav-item active">
-      <a class="nav-link" href="#">Home<span class="sr-only">(current)</span></a>
-    </li>
-    {% endblock %}
+{% block Home %}
+<li class="nav-item active">
+  <a class="nav-link" href="#">Home<span class="sr-only">(current)</span></a>
+</li>
+{% endblock %}
 
-    {% block adminManagement %}
-    <!-- Hide admin buttons (we'll add logic to handle this here later) -->
-    {% endblock %}
-
-    {% block content %}
-      <div class="jumbotron">
-        <h1>EPL Web App HomePage</h1>
-        <p>This will display anything on the homepage.</p>
-      </div>
-    </div> <!-- /container -->
-    {% endblock %}
+{% block content %}
+  <div class="jumbotron">
+    <h1>EPL Web App HomePage</h1>
+    <p>This will display anything on the homepage.</p>
+  </div>
+</div> <!-- /container -->
+{% endblock %}
 
 {# 
 <!DOCTYPE html>

--- a/views/_layout.njk
+++ b/views/_layout.njk
@@ -26,7 +26,7 @@
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
-            <a class="navbar-brand" href="#">EPL WEB APP</a>
+            <a class="navbar-brand" href="/">EPL WEB APP</a>
           </div> <!--navbar-header-->
 
           <!-- Collect the nav links and content for toggling -->
@@ -45,25 +45,36 @@
               </li>
               {% endblock %}
 
-              {% block AdminLogin %}
-              <li class="nav-item">
-                  <a class="nav-link" href="/adminLogin">Admin Login</a>
-              </li>
-              {% endblock %}
+              {% if not authenticated %}
+                {% block AdminLogin %}
+                <li class="nav-item">
+                    <a class="nav-link" href="/adminLogin">Admin Login</a>
+                </li>
+                {% endblock %}
+              {% endif %}
 
               <!-- The adminManagement block should only be displayed (inherited) if an admin "session" is active -->
-              {% block adminManagement %}
-              <li class="nav-item dropdown">
-                  <a class="nav-link dropdown-toggle" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Management</a>
-                  <div class="dropdown-menu" aria-labelledby="dropdown10">
-                    <a class="dropdown-item" href="/userManagement">User</a>
-                    <a class="dropdown-item" href="/stationManagement/all">Station</a>
-                  </div>
-              </li>
-              <li class="nav-item">
-                  <a class="nav-link" href="#">Log Out</a>
-              </li>
-              {% endblock %} <!-- /end adminManagment block -->
+              {% if authenticated %}
+                {% block adminManagement %}
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Management</a>
+                    <div class="dropdown-menu" aria-labelledby="dropdown10">
+                      <a class="dropdown-item" href="/userManagement">User</a>
+                      <a class="dropdown-item" href="/stationManagement/all">Station</a>
+                    </div>
+                </li>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="dropdown11" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Account</a>
+                    <div class="dropdown-menu" aria-labelledby="dropdown11">
+                      <a class="dropdown-item" href="/adminRegister">Register new admin</a>
+                      <a class="dropdown-item" href="/adminReset">Change account password</a>
+                    </div>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="/logout">Log Out</a>
+                </li>
+                {% endblock %} <!-- /end adminManagment block -->
+              {% endif %}
 
             </ul> <!-- /navbar-nav mr-auto -->
           </div> <!-- /navbarCollapse -->

--- a/views/adminLogin.njk
+++ b/views/adminLogin.njk
@@ -19,10 +19,6 @@
 </li>
 {% endblock %}
 
-{% block adminManagement %}
-<!-- Hide admin buttons (we'll add logic to handle this here later) -->
-{% endblock %}
-
 {% block content %}
   <form class="form-signin" method="POST" action="/adminLogin">
     <h2 class="form-signin-heading">Please sign in</h2>

--- a/views/badgein.njk
+++ b/views/badgein.njk
@@ -1,37 +1,33 @@
 {% extends '_layout.njk' %}
 
-    {% block description %}
-    <meta name="description" content="a page for the user to sign in his badge.">
-    {% endblock %}
+{% block description %}
+<meta name="description" content="a page for the user to sign in his badge.">
+{% endblock %}
 
-    {% block title %}
-    <title>Badge In Page</title>
-    {% endblock %}
+{% block title %}
+<title>Badge In Page</title>
+{% endblock %}
 
-    <!-- Custom styles for this template -->
-    {% block customCSS %}
-    <link rel="stylesheet" href="/stylesheets/badgein.css">
-    {% endblock %}
+<!-- Custom styles for this template -->
+{% block customCSS %}
+<link rel="stylesheet" href="/stylesheets/badgein.css">
+{% endblock %}
 
-    {% block Badgein %}
-    <li class="nav-item active">
-      <a class="nav-link" href="#">Badge-in<span class="sr-only">(current)</span></a>
-    </li>
-    {% endblock %}
+{% block Badgein %}
+<li class="nav-item active">
+  <a class="nav-link" href="#">Badge-in<span class="sr-only">(current)</span></a>
+</li>
+{% endblock %}
 
-    {% block adminManagement %}
-    <!-- Hide admin buttons (we'll add logic to handle this here later) -->
-    {% endblock %}
-
-    {% block content %}
-        <form action="/badgein" method="post">
-        <h1>Please enter or scan badge</h1>
-        <div class="center">
-          <input type="text" name="badgeNumber" placeholder="Enter Badge ID"required>
-        </div>
-        <button class="btn btn-primary" type="Submit">Submit</button>
-        </form>
-    {% endblock %}
+{% block content %}
+    <form action="/badgein" method="post">
+    <h1>Please enter or scan badge</h1>
+    <div class="center">
+      <input type="text" name="badgeNumber" placeholder="Enter Badge ID"required>
+    </div>
+    <button class="btn btn-primary" type="Submit">Submit</button>
+    </form>
+{% endblock %}
 
 
 

--- a/views/badgeinSuccess.njk
+++ b/views/badgeinSuccess.njk
@@ -1,31 +1,27 @@
 {% extends '_layout.njk' %}
 
-    {% block description %}
-    <meta name="description" content="a page appeared for the user when the badge in success.">
-    {% endblock %}
+{% block description %}
+<meta name="description" content="a page appeared for the user when the badge in success.">
+{% endblock %}
 
-    {% block title %}
-    <title>Badge In Success</title>
-    {% endblock %}
+{% block title %}
+<title>Badge In Success</title>
+{% endblock %}
 
-    <!-- Custom styles for this template -->
-    {% block customCSS %}
-    <link rel="stylesheet" href="stylesheets/badgeinSuccess.css">
-    {% endblock %}
+<!-- Custom styles for this template -->
+{% block customCSS %}
+<link rel="stylesheet" href="stylesheets/badgeinSuccess.css">
+{% endblock %}
 
-    {% block adminManagement %}
-    <!-- Hide admin buttons (we'll add logic to handle this here later) -->
-    {% endblock %}
-
-    {% block content %}
-        <form action="/badgeinSuccess" method="post">
-        <div class="alert alert-success">
-         <strong> Badge In Success</strong>
-        </div>
-        <h1>Please  Enter   OK </h1>
-        <button class="btn btn-primary" type="Submit">OK</button>
-        </form>
-    {% endblock %}
+{% block content %}
+    <form action="/badgeinSuccess" method="post">
+    <div class="alert alert-success">
+      <strong> Badge In Success</strong>
+    </div>
+    <h1>Please  Enter   OK </h1>
+    <button class="btn btn-primary" type="Submit">OK</button>
+    </form>
+{% endblock %}
 
 
 

--- a/views/registration.njk
+++ b/views/registration.njk
@@ -12,10 +12,6 @@
 <link rel="stylesheet" href="/stylesheets/registration.css">
 {% endblock %}
 
-{% block adminManagement %}
-<!-- Hide admin buttons (we'll add logic to handle this here later) -->
-{% endblock %}
-
 {% block content %}
 <img src="/images/liability_terms.PNG" alt="Liability form">
 <form method="POST">

--- a/views/userManagement.njk
+++ b/views/userManagement.njk
@@ -12,13 +12,7 @@
 <link rel="stylesheet" href="/stylesheets/userManagement.css">
 {% endblock %}
 
-{% block adminManagement %}
-<!-- Hide admin buttons (we'll add logic to handle this here later) -->
-{% endblock %}
-
 {% block content %}
-
-
 <div class="panel panel-default user_panel">
     <div class="panel-heading">
         <h3 class="panel-title"><center>User Management Page</center></h3>
@@ -38,8 +32,6 @@
         </div>         
     </div>
 </div>
-
-
 
 <table class="table">
     <thead>


### PR DESCRIPTION
- Routes that should just be accessed by admin are now protected using the `checkAuth` middleware function. Use this function when you want a route to only be accessed by an admin when they are logged in.
- Logging in as an admin will allow you to access those paths.
- The nav bar will now display the appropriate items if an admin is logged in or not. If no one is logged in then it will only display the "Home", "Badge-in", and "Admin login" items. If an admin is logged in then the "Admin login" will disappear and "Management", "Account", and "Logout" items will appear.
- An "Account" dropdown has been added, allowing access to be able to register a new admin, or change your account password.
- Let me know if I missed anything, or if you have any other suggestions.