### PR TITLE
Bugfix: Station management page on/off values were backwards

### DIFF
--- a/public/javascripts/userManagement.js
+++ b/public/javascripts/userManagement.js
@@ -47,7 +47,7 @@ $('#search').on("click", function(event) {
    event.preventDefault();
 
   // Grab values from elements in searchForm:
-  var $form = $('#searchForm'),
+  let $form = $('#searchForm'),
     name = $("#name").val(),
     dateRange = $("#dateRange").val(),
     status = $("#statusSelector").val(),
@@ -56,7 +56,7 @@ $('#search').on("click", function(event) {
     url = '/userManagement';
   
   // Send the data using post
-  var posting = $.post( url, {
+  let posting = $.post( url, {
     nameInput: name,
     dateFilter: dateRange,
     statusSelector: status,
@@ -67,13 +67,13 @@ $('#search').on("click", function(event) {
   // Put the results in a div
   posting.done(function(data) {
     $('tbody').empty();
-    var tr = $('<tr></tr>'); //creates row
-    var td = $('<td></td>'); //creates cell
+    let tr = $('<tr></tr>'); //creates row
+    let td = $('<td></td>'); //creates cell
 
     // Create a row for each user from POST and append elements
     $.each(data.users, function (index, user) {
-      var row = tr.clone(); //deep copy
-      var butt = $('<button class="btn btn-primary" onclick="fwd(this)" data-badge="' + user.badge + '">Edit details</button>');
+      let row = tr.clone(); //deep copy
+      let butt = $('<button class="btn btn-primary" onclick="fwd(this)" data-badge="' + user.badge + '">Edit details</button>');
       row.append(td.clone().text(user.first + " " + user.last));
       row.append(td.clone().text(user.badge));
       row.append(td.clone().text(user.confirmation));

--- a/routes/index.js
+++ b/routes/index.js
@@ -640,21 +640,20 @@ var checkAuth = function (req, res, next) {
 
 
 /*getStnMngmnt will render a table of all stations that match filter parameter.
-  *    If filter == "registered", only registered stations will be displayed (i.e. registered = true)
-  *    If filter == "unregistered", only unregistered stations will be displayed (i.e. registered = false)
+  *    If filter == "online", only online stations will be displayed (i.e. registered = true)
+  *    If filter == "offline", only offline stations will be displayed (i.e. registered = false)
   *    Otherwise, all stations will be displayed sorted with unregistered stations first.
   *********************************************************************************************************/
 function getStnMngmnt(req, res) {
   //set filter based on query parameter passed in
   var data = { authenticated: true }
   var filter = req.params.filter;
-  filter = (filter === "registered") ? true : (filter === "unregistered") ? false : undefined;
+  filter = (filter === "online") ? true : (filter === "offline") ? false : undefined;
 
   Promise.all([
     dbAPI.getStations(filter),
     userStationAPI.getAll()
-  ])
-    .then(
+  ]).then(
       ([ret, userStationRel]) => {
         if (ret !== false && ret !== undefined) {
           ret.sort(function (a, b) {

--- a/views/stationManagement.njk
+++ b/views/stationManagement.njk
@@ -38,8 +38,8 @@
           Filter Stations
         </button>
         <div class="dropdown-menu" aria-labelledby="dropRightMenu">
-          <a class="dropdown-item" href="/stationManagement/unregistered">Online Stations</a>
-          <a class="dropdown-item" href="/stationManagement/registered">Offline Stations</a>
+          <a class="dropdown-item" href="/stationManagement/online">Online Stations</a>
+          <a class="dropdown-item" href="/stationManagement/offline">Offline Stations</a>
           <a class="dropdown-item" href="/stationManagement/all">All Stations</a>
         </div>
       </div>


### PR DESCRIPTION
Bishoy noticed the values were backwards on these. The URL values attached to the dropdown menus on the stationManagement page were accidentally swapped. I went ahead and changed the url to match the text displayed on the page - cuz, why not?

I changed a few more "var"s to "let" also.