### PR TITLE
delete user fix and make current navbar link(s) active

### DIFF
--- a/public/javascripts/updateUserInfo.js
+++ b/public/javascripts/updateUserInfo.js
@@ -7,6 +7,8 @@
 /******************************************************************/
 
 $(function () {
+  $('#userNav').addClass("active")
+  
   $('#updateUser').on('click', function () {    
     let updatedData = {};
 

--- a/public/javascripts/userManagement.js
+++ b/public/javascripts/userManagement.js
@@ -8,6 +8,7 @@
 
 $(function() {
   $('#search').trigger('click');
+  $('#userNav').addClass("active");
 });
 
 $(function() {

--- a/views/_layout.njk
+++ b/views/_layout.njk
@@ -69,13 +69,15 @@
               {% if authenticated %}
                 {% block adminManagement %}
                 <li class="nav-item dropdown">
+                    {% block adminCurrent %}
                     <a class="nav-link dropdown-toggle" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management</a>
+                    {% endblock %}
                     <div class="dropdown-menu" aria-labelledby="dropdown10">
-                      <a class="dropdown-item" href="/userManagement">Users</a>
-                      <a class="dropdown-item" href="/stationManagement/all">Stations</a>
-                      <a class="dropdown-item" href="/eventsLog/all">Events</a>
-                      <a class="dropdown-item" href="/adminRegister">Register new admin</a>
-                      <a class="dropdown-item" href="/adminReset">Reset an admin password</a>
+                      <a class="dropdown-item" id="userNav" href="/userManagement">Users</a>
+                      <a class="dropdown-item" id="stationNav" href="/stationManagement/all">Stations</a>
+                      <a class="dropdown-item" id="eventsNav" href="/eventsLog/all">Events</a>
+                      <a class="dropdown-item" id="regAdminNav" href="/adminRegister">Register new admin</a>
+                      <a class="dropdown-item" id="resetAdminNav" href="/adminReset">Reset an admin password</a>
                     </div>
                 </li>
                 <li class="nav-item">

--- a/views/adminLogin.njk
+++ b/views/adminLogin.njk
@@ -12,6 +12,12 @@
 <meta name="description" content="Login page to input credentials for authorization and authentication.">
 {% endblock %}
 
+{% block AdminLogin %}
+<li class="nav-item active">
+  <a class="nav-link" href="/adminLogin">Admin Login<span class="sr-only">(current)</span></a>
+</li>
+{% endblock %}
+
 {% block title %}
   <title>LUCCA Admin Login</title>
 {% endblock %}

--- a/views/adminRegister.njk
+++ b/views/adminRegister.njk
@@ -8,6 +8,10 @@
 
 {% extends '_layout.njk' %}
 
+{% block adminCurrent %}
+<a class="nav-link dropdown-toggle active" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management<span class="sr-only">(current)</span></a>
+{% endblock %}
+
 {% block content %}
 <form action="/adminRegister" method="POST">
   <h2>Promote exiting user to admin</h2>
@@ -22,4 +26,12 @@
     </div>
   <button class="btn btn-primary" type="submit" role="button">Sign Up</button>
 </form>
+{% endblock %}
+
+{% block custom_scripts %}
+<script>
+  $(function() {
+    $('#regAdminNav').addClass("active");
+  });
+</script>
 {% endblock %}

--- a/views/adminReset.njk
+++ b/views/adminReset.njk
@@ -8,6 +8,10 @@
 
 {% extends '_layout.njk' %}
 
+{% block adminCurrent %}
+<a class="nav-link dropdown-toggle active" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management<span class="sr-only">(current)</span></a>
+{% endblock %}
+
 {% block content %}
 <form action="/adminReset" method="POST">
   <h2>Reset your admin (or another admins) account password</h2>
@@ -22,4 +26,12 @@
     </div>
   <button class="btn btn-primary" type="submit" role="button">Reset password</button>
 </form>
+{% endblock %}
+
+{% block custom_scripts %}
+<script>
+  $(function() {
+    $('#resetAdminNav').addClass("active");
+  });
+</script>
 {% endblock %}

--- a/views/badgein.njk
+++ b/views/badgein.njk
@@ -23,7 +23,7 @@
 
 {% block Badgein %}
 <li class="nav-item active">
-  <a class="nav-link" href="#">Badge-in<span class="sr-only">(current)</span></a>
+  <a class="nav-link" href="/badgein">Badge-in<span class="sr-only">(current)</span></a>
 </li>
 {% endblock %}
 

--- a/views/eventsLog.njk
+++ b/views/eventsLog.njk
@@ -16,6 +16,10 @@
 <title>LUCCA Events Log</title>
 {% endblock %}
 
+{% block adminCurrent %}
+<a class="nav-link dropdown-toggle active" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management<span class="sr-only">(current)</span></a>
+{% endblock %}
+
 {% block content %}
 
 <!-- Main page description -->
@@ -83,4 +87,12 @@
 </container>
 <!-- /container table for filtered station results -->
 <br /><br />
+{% endblock %}
+
+{% block custom_scripts %}
+<script>
+  $(function() {
+    $('#eventsNav').addClass("active");
+  });
+</script>
 {% endblock %}

--- a/views/stationManagement.njk
+++ b/views/stationManagement.njk
@@ -16,6 +16,10 @@
 <title>LUCCA Station Management</title>
 {% endblock %}
 
+{% block adminCurrent %}
+<a class="nav-link dropdown-toggle active" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management<span class="sr-only">(current)</span></a>
+{% endblock %}
+
 {% block content %}
 <!-- Main page description -->
 <div class="panel panel-default user_panel">
@@ -118,4 +122,12 @@
 </container>
 <!-- /container table for filtered station results -->
 <br /><br />
+{% endblock %}
+
+{% block custom_scripts %}
+<script>
+  $(function() {
+    $('#stationNav').addClass("active");
+  });
+</script>
 {% endblock %}

--- a/views/userManagement.njk
+++ b/views/userManagement.njk
@@ -16,6 +16,10 @@
 <title>LUCCA User Management</title>
 {% endblock %}
 
+{% block adminCurrent %}
+<a class="nav-link dropdown-toggle active" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management<span class="sr-only">(current)</span></a>
+{% endblock %}
+
 {% block content %}
 <div class="panel panel-default user_panel">
     <div class="panel-heading">

--- a/views/userManagementBadge.njk
+++ b/views/userManagementBadge.njk
@@ -20,6 +20,10 @@
 <link rel="stylesheet" href="/stylesheets/userManagement.css">
 {% endblock %}
 
+{% block adminCurrent %}
+<a class="nav-link dropdown-toggle active" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management<span class="sr-only">(current)</span></a>
+{% endblock %}
+
 {% block content %}
 {# User Information Table #}
 <div class="container mb-3 pb-3">


### PR DESCRIPTION
- No longer get internal error message and/or empty list { } displayed after clicking delete on a user and then "Back" on your browser.

- Added a "user traffic" log event to associate deleted user event with badge# (is persistent and will show up if/when user tries to re-register)

- Appropriate navbar links (and dropdown items) now show up as active when on related page(s).