### PR TITLE
Mike o no update user blank fields and no number names

### DIFF
--- a/public/javascripts/updateUserInfo.js
+++ b/public/javascripts/updateUserInfo.js
@@ -7,6 +7,8 @@
 /******************************************************************/
 
 $(function () {
+  $('#userNav').addClass("active")
+  
   $('#updateUser').on('click', function () {    
     let updatedData = {};
 

--- a/public/javascripts/userManagement.js
+++ b/public/javascripts/userManagement.js
@@ -8,6 +8,7 @@
 
 $(function() {
   $('#search').trigger('click');
+  $('#userNav').addClass("active");
 });
 
 $(function() {

--- a/routes/index.js
+++ b/routes/index.js
@@ -620,7 +620,7 @@ module.exports = function (passport) {
   });
 
   
-  router.post('/userManagement/updateUserInfo/:badge', [
+  router.post('/userManagement/updateUserInfo/:badge', checkAuth, [
     check('first')
       .trim()
       .not().isEmpty().withMessage('First name cannot be left blank')

--- a/routes/index.js
+++ b/routes/index.js
@@ -353,6 +353,7 @@ module.exports = function (passport) {
       dbAPI.logEvent('user traffic', deletedBadge, `User with badge ID: ${deletedBadge} has been deleted by Admin ${adminName}`);
       req.flash('success', 'The user has been successfully deleted from the system');
       req.flash('fade_out', '3000');
+      res.redirect('/userManagement');
     }).catch(
       err => {
         const errMessage = "Internal database error: Unable to delete user with badge number" + req.params.badge
@@ -361,8 +362,6 @@ module.exports = function (passport) {
         res.redirect('/userManagement');
       }
     );
-
-    res.redirect('/userManagement');
   });
 
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -116,9 +116,15 @@ module.exports = function (passport) {
         });
       }),
 
-    check('first').exists().withMessage('Please enter first name'),
+    check('first')
+      .exists().withMessage('Please enter first name')
+      .trim()
+      .not().matches(/[^0-9]*\d+?[^0-9]*/).withMessage('First name cannot contain numbers'),
 
-    check('last').exists().withMessage('Please enter last name'),
+    check('last')
+      .exists().withMessage('Please enter last name')
+      .trim()
+      .not().matches(/[^0-9]*\d+?[^0-9]*/).withMessage('Last name cannot contain numbers'),
 
     check('email')
       .exists()
@@ -136,13 +142,20 @@ module.exports = function (passport) {
       .exists()
       .isMobilePhone('any').withMessage('Please enter valid phone number'),
 
-    check('signature').exists().withMessage('Please enter signature'),
+    check('signature', 'Electronic singature must be your \"Firstname Lastname\"')
+      .exists()
+      .trim()
+      .custom((value, { req }) => value === req.body.first + " " + req.body.last),
 
     check('ecSignature').exists(),
 
-    check('ecName').exists().withMessage('Please enter emergency contact name'),
+    check('ecName')
+      .exists().withMessage('Please enter emergency contact name')
+      .trim()
+      .not().matches(/[^0-9]*\d+?[^0-9]*/).withMessage('Emergency contact name cannot contain numbers'),
 
-    check('ecRel').exists().withMessage('Please enter emergency contact relationship'),
+    check('ecRel')
+      .exists().withMessage('Please enter emergency contact relationship'),
 
     check('ecPhone')
       .exists()
@@ -608,6 +621,18 @@ module.exports = function (passport) {
 
   
   router.post('/userManagement/updateUserInfo/:badge', [
+    check('first')
+      .trim()
+      .not().isEmpty().withMessage('First name cannot be left blank')
+      .not().matches(/[^0-9]*\d+?[^0-9]*/).withMessage('First name cannot contain numbers')
+      .optional(),
+
+    check('last')
+      .trim()
+      .not().isEmpty().withMessage('Last name cannot be left blank')
+      .not().matches(/[^0-9]*\d+?[^0-9]*/).withMessage('Last name cannot contain numbers')
+      .optional(),
+
     check('email')
       .exists()
       .isEmail().withMessage('Please enter valid email')
@@ -623,6 +648,17 @@ module.exports = function (passport) {
 
     check('phone')
       .isMobilePhone('any').withMessage('Please enter valid phone number')
+      .optional(),
+
+      check('ecName')
+      .trim()
+      .not().isEmpty().withMessage('Emergency contact name cannot be blank')
+      .not().matches(/[^0-9]*\d+?[^0-9]*/).withMessage('Emergency contact name cannot contain numbers')
+      .optional(),
+
+    check('ecRel')
+      .trim()
+      .not().isEmpty().withMessage('Emergency contact relationship cannot be blank')
       .optional(),
 
     check('ecPhone')

--- a/views/_layout.njk
+++ b/views/_layout.njk
@@ -69,13 +69,15 @@
               {% if authenticated %}
                 {% block adminManagement %}
                 <li class="nav-item dropdown">
+                    {% block adminCurrent %}
                     <a class="nav-link dropdown-toggle" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management</a>
+                    {% endblock %}
                     <div class="dropdown-menu" aria-labelledby="dropdown10">
-                      <a class="dropdown-item" href="/userManagement">Users</a>
-                      <a class="dropdown-item" href="/stationManagement/all">Stations</a>
-                      <a class="dropdown-item" href="/eventsLog/all">Events</a>
-                      <a class="dropdown-item" href="/adminRegister">Register new admin</a>
-                      <a class="dropdown-item" href="/adminReset">Reset an admin password</a>
+                      <a class="dropdown-item" id="userNav" href="/userManagement">Users</a>
+                      <a class="dropdown-item" id="stationNav" href="/stationManagement/all">Stations</a>
+                      <a class="dropdown-item" id="eventsNav" href="/eventsLog/all">Events</a>
+                      <a class="dropdown-item" id="regAdminNav" href="/adminRegister">Register new admin</a>
+                      <a class="dropdown-item" id="resetAdminNav" href="/adminReset">Reset an admin password</a>
                     </div>
                 </li>
                 <li class="nav-item">

--- a/views/adminLogin.njk
+++ b/views/adminLogin.njk
@@ -12,6 +12,12 @@
 <meta name="description" content="Login page to input credentials for authorization and authentication.">
 {% endblock %}
 
+{% block AdminLogin %}
+<li class="nav-item active">
+  <a class="nav-link" href="/adminLogin">Admin Login<span class="sr-only">(current)</span></a>
+</li>
+{% endblock %}
+
 {% block title %}
   <title>LUCCA Admin Login</title>
 {% endblock %}

--- a/views/adminRegister.njk
+++ b/views/adminRegister.njk
@@ -8,6 +8,10 @@
 
 {% extends '_layout.njk' %}
 
+{% block adminCurrent %}
+<a class="nav-link dropdown-toggle active" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management<span class="sr-only">(current)</span></a>
+{% endblock %}
+
 {% block content %}
 <form action="/adminRegister" method="POST">
   <h2>Promote exiting user to admin</h2>
@@ -22,4 +26,12 @@
     </div>
   <button class="btn btn-primary" type="submit" role="button">Sign Up</button>
 </form>
+{% endblock %}
+
+{% block custom_scripts %}
+<script>
+  $(function() {
+    $('#regAdminNav').addClass("active");
+  });
+</script>
 {% endblock %}

--- a/views/adminReset.njk
+++ b/views/adminReset.njk
@@ -8,6 +8,10 @@
 
 {% extends '_layout.njk' %}
 
+{% block adminCurrent %}
+<a class="nav-link dropdown-toggle active" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management<span class="sr-only">(current)</span></a>
+{% endblock %}
+
 {% block content %}
 <form action="/adminReset" method="POST">
   <h2>Reset your admin (or another admins) account password</h2>
@@ -22,4 +26,12 @@
     </div>
   <button class="btn btn-primary" type="submit" role="button">Reset password</button>
 </form>
+{% endblock %}
+
+{% block custom_scripts %}
+<script>
+  $(function() {
+    $('#resetAdminNav').addClass("active");
+  });
+</script>
 {% endblock %}

--- a/views/badgein.njk
+++ b/views/badgein.njk
@@ -23,7 +23,7 @@
 
 {% block Badgein %}
 <li class="nav-item active">
-  <a class="nav-link" href="#">Badge-in<span class="sr-only">(current)</span></a>
+  <a class="nav-link" href="/badgein">Badge-in<span class="sr-only">(current)</span></a>
 </li>
 {% endblock %}
 

--- a/views/eventsLog.njk
+++ b/views/eventsLog.njk
@@ -16,6 +16,10 @@
 <title>LUCCA Events Log</title>
 {% endblock %}
 
+{% block adminCurrent %}
+<a class="nav-link dropdown-toggle active" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management<span class="sr-only">(current)</span></a>
+{% endblock %}
+
 {% block content %}
 
 <!-- Main page description -->
@@ -83,4 +87,12 @@
 </container>
 <!-- /container table for filtered station results -->
 <br /><br />
+{% endblock %}
+
+{% block custom_scripts %}
+<script>
+  $(function() {
+    $('#eventsNav').addClass("active");
+  });
+</script>
 {% endblock %}

--- a/views/stationManagement.njk
+++ b/views/stationManagement.njk
@@ -16,6 +16,10 @@
 <title>LUCCA Station Management</title>
 {% endblock %}
 
+{% block adminCurrent %}
+<a class="nav-link dropdown-toggle active" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management<span class="sr-only">(current)</span></a>
+{% endblock %}
+
 {% block content %}
 <!-- Main page description -->
 <div class="panel panel-default user_panel">
@@ -118,4 +122,12 @@
 </container>
 <!-- /container table for filtered station results -->
 <br /><br />
+{% endblock %}
+
+{% block custom_scripts %}
+<script>
+  $(function() {
+    $('#stationNav').addClass("active");
+  });
+</script>
 {% endblock %}

--- a/views/userManagement.njk
+++ b/views/userManagement.njk
@@ -16,6 +16,10 @@
 <title>LUCCA User Management</title>
 {% endblock %}
 
+{% block adminCurrent %}
+<a class="nav-link dropdown-toggle active" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management<span class="sr-only">(current)</span></a>
+{% endblock %}
+
 {% block content %}
 <div class="panel panel-default user_panel">
     <div class="panel-heading">

--- a/views/userManagementBadge.njk
+++ b/views/userManagementBadge.njk
@@ -20,6 +20,10 @@
 <link rel="stylesheet" href="/stylesheets/userManagement.css">
 {% endblock %}
 
+{% block adminCurrent %}
+<a class="nav-link dropdown-toggle active" href="#" id="dropdown10" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Admin management<span class="sr-only">(current)</span></a>
+{% endblock %}
+
 {% block content %}
 {# User Information Table #}
 <div class="container mb-3 pb-3">

--- a/views/userManagementBadge.njk
+++ b/views/userManagementBadge.njk
@@ -105,11 +105,16 @@
                 </tr>
                 <tr>
                     <th></th>
+                    <td>
+                        <form id="deleteForm" action="/userManagement/deleteUser/{{user.badge}}" method="post">
+                        <button type='submit' class="btn btn-primary" name='submit' value="">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                <tr>
+                    <th></th>
                     {% if user.confirmation  %}
                         <td>
-                            <form id="deleteForm" action="/userManagement/deleteUser/{{user.badge}}" method="post">
-                            <button type='submit' class="btn btn-primary" name='submit' value="">Delete</button>
-                            </form>
                         {% if user.status == "User"%}
                             <br> 
                             <form id="ChangeStatusToManager" action="/userManagement/promoteUser/{{user.badge}}" method="post">        


### PR DESCRIPTION
This pull request has my other branch's changes, but I wanted to keep them separate so I didn't lump too many changes together. This addresses more findings from our front end tests:

- userManagement/updateUserInfo route no longer allows admin to save an empty string when updating a user's first name, last name, emergency contact name, nor emergency relationship fields.

- An admin no longer has to "Validate" a user's registration before he/she can "Delete" the user.

- Participant's electronic signature must now match the user's entered "Firstname Lastname".

- First name, Last name, and Emergency contact name fields disallow numerical input in registration and updateUserInfo routes.

- Added a "checkAuth" call to protect admin updateUserInfo route